### PR TITLE
Add variable to jivelite script for hardware rotations.

### DIFF
--- a/jivelite-sp
+++ b/jivelite-sp
@@ -15,6 +15,13 @@
 
 export LOG=/var/log/pcp_jivelite.log
 
+#Variables coming from pcp.cfg
+# SCREENROTATE
+# HARDWARE_ROT
+# JL_FRAME_RATE
+# JL_FRAME_DEPTH
+# JL_FRAME_BUFFER
+
 if [ -f /usr/local/etc/pcp/pcp.cfg ]; then
     source /usr/local/etc/pcp/pcp.cfg
 fi
@@ -77,10 +84,12 @@ if [ ! -z ${SCREENROTATE} ]; then
             *) unset SDL_VIDEO_FBCON_ROTATION;;
         esac
     fi
+    [ "${HARDWARE_ROT}" = "yes" ] && unset SDL_VIDEO_FBCON_ROTATION
+
     if [ ! -z ${SDL_VIDEO_FBCON_ROTATION} ]; then
         echo "SDL screen rotation set to $SDL_VIDEO_FBCON_ROTATION." >> $LOG
     else
-        echo "No Screen rotation, or handled in firmware." >> $LOG
+        echo "No SDL Screen rotation, or handled in hardware/drivers." >> $LOG
     fi
 fi
 
@@ -99,10 +108,7 @@ fi
 if [ ${DRIVER} != "VC4" ]; then
     /usr/sbin/fbset -depth $JL_FRAME_DEPTH >> $LOG
 else
-    case "${SCREENROTATE}" in
-        0) break;;
-        *) JL_FRAME_DEPTH=16;;
-    esac
+    [ "${HARDARE_ROT}" = "yes" ] || JL_FRAME_DEPTH=16
 fi
 echo "Frame buffer color bit depth set to $JL_FRAME_DEPTH." >> $LOG
 


### PR DESCRIPTION
This turned into a mess.

Pi04: BCM Firmware can Rotate the touchscreens or HDMI in any direction
Pi04: VC4 driver can Rotate Touchscreens or HDMI 180, but not 90 or 270
Pi5: Can't rotate anything.

I'll leave detection of Hardware Rotate in the pCP interface.  But it would be easy for anyone to override with a custom version of the script.